### PR TITLE
Bump to FeatureBase v3.33.0

### DIFF
--- a/docker-cluster/Dockerfile
+++ b/docker-cluster/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /featurebase
 COPY featurebase.conf /featurebase
 
 # download and setup featurebase
-RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.32.0/featurebase-v3.32.0-linux-amd64.tar.gz
+RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.33.0/featurebase-v3.33.0-linux-amd64.tar.gz
 RUN tar xvfz featurebase*.gz
 RUN mkdir /var/log/featurebase/
 

--- a/docker-cluster/start-processes.sh
+++ b/docker-cluster/start-processes.sh
@@ -18,4 +18,4 @@ if [ "$IP_ADDRESS" = "$IP_HOST_THREE" ]; then
 fi
 
 # start featurebase
-/featurebase/fb/featurebase server --config featurebase.conf --name $NAME --sql.endpoint-enabled --advertise featurebase:10101 --bind $IP_ADDRESS:$BIND_PORT --etcd.listen-client-address http://$IP_ADDRESS:$CLIENT_PORT --etcd.listen-peer-address http://$IP_ADDRESS:$PEER_PORT --etcd.initial-cluster="featurebase1=http://$IP_HOST_ONE:10301,featurebase4=http://$IP_HOST_FOUR:40301,featurebase3=http://$IP_HOST_THREE:30301"
+/featurebase/fb/featurebase server --config featurebase.conf --name $NAME --advertise featurebase:10101 --bind $IP_ADDRESS:$BIND_PORT --etcd.listen-client-address http://$IP_ADDRESS:$CLIENT_PORT --etcd.listen-peer-address http://$IP_ADDRESS:$PEER_PORT --etcd.initial-cluster="featurebase1=http://$IP_HOST_ONE:10301,featurebase4=http://$IP_HOST_FOUR:40301,featurebase3=http://$IP_HOST_THREE:30301"

--- a/docker-consumer/Dockerfile
+++ b/docker-consumer/Dockerfile
@@ -14,7 +14,7 @@ COPY sample.csv /featurebase
 COPY start.sh /featurebase
 
 # download and setup featurebase
-RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.32.0/featurebase-v3.32.0-linux-amd64.tar.gz
+RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.33.0/featurebase-v3.33.0-linux-amd64.tar.gz
 RUN tar xvfz featurebase*.gz
 RUN mkdir /var/log/featurebase/
 

--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -16,7 +16,7 @@ COPY schema.json /featurebase
 COPY set-schema.json /featurebase
 
 # download and setup featurebase
-RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.32.0/featurebase-v3.32.0-linux-amd64.tar.gz
+RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.33.0/featurebase-v3.33.0-linux-amd64.tar.gz
 RUN tar xvfz featurebase*.gz
 RUN mkdir /var/log/featurebase/
 

--- a/docker-example/start-processes.sh
+++ b/docker-example/start-processes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # start featurebase
-/featurebase/fb/featurebase server --config featurebase.conf --sql.endpoint-enabled &
+/featurebase/fb/featurebase server --config featurebase.conf &
 
 # create topic
 sleep 15

--- a/docker-simple/Dockerfile
+++ b/docker-simple/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /featurebase
 COPY featurebase.conf /featurebase
 
 # download and setup featurebase
-RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.32.0/featurebase-v3.32.0-linux-amd64.tar.gz
+RUN wget https://github.com/FeatureBaseDB/featurebase/releases/download/v3.33.0/featurebase-v3.33.0-linux-amd64.tar.gz
 RUN tar xvfz featurebase*.gz
 RUN mkdir /var/log/featurebase/
 

--- a/docker-simple/Dockerfile
+++ b/docker-simple/Dockerfile
@@ -31,4 +31,4 @@ RUN chmod 755 idk/*
 EXPOSE 10101/tcp
 EXPOSE 20101/tcp
 
-ENTRYPOINT ["/featurebase/fb/featurebase","server","--config","featurebase.conf", "--sql.endpoint-enabled"]
+ENTRYPOINT ["/featurebase/fb/featurebase","server","--config","featurebase.conf"]


### PR DESCRIPTION
FeatureBase v3.33.0 is released.  SQL endpoint enabled has been removed, since SQL is now turned on by default in FeatureBase. 🚀